### PR TITLE
fix: various error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ export class Dedupr {
             const results = Object.values(this.results)
 
             // Filter only files that had duplicates, excluding error entries.
-            const duplicates = results.filter((r) => r?.duplicates.length > 0)
+            const duplicates = results.filter((r) => r.duplicates?.length > 0)
             const count = duplicates.map((d) => d.duplicates.length).reduce((a, b) => a + b, 0)
 
             logInfo(this.options, `Found ${results.length} distinct files and ${count} duplicates`)


### PR DESCRIPTION
1. File permission issues cause entries that have no `.duplicates` property, only `.err` message.
2. Unsynchronized (virtual) cloud files throw an error after getting a file descriptor, so it makes sense to wrap the reading into `try-finally` block to ensure that the descriptor gets closed and your CLI tool does not hang infinitely.